### PR TITLE
Add a switch to avoid restart of keepalived after conf modification if wanted

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Another role or deployment method must be devised to use notification scripts su
 * `keepalived_vrrp_instances`: configure one or more `vrrp_instance`.
 * `keepalived_flags`: flags to pass to the keepalived daemon (set `--log-detail --log-facility=7` by default)
 
+## Default variables
+
+* `keepalived_install`: Install keepalived package (`no` by default)
+* `keepalived_packages`: list of packages to install keeplived (depending on distribution version)
+* `keepalived_auto_restart`: automatically restart keepalived when conf is changed (`yes` by default)
+
 ## Dependencies
 
 The `keepalived` package should be installed first using a tool such as Packer.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 keepalived_install: no
+keepalived_auto_restart: yes
 keepalived_packages: "{{ __keepalived_packages }}"
 keepalived_flags: "--log-detail --log-facility=7"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: keepalived
     state: restarted
+  when: keepalived_auto_restart


### PR DESCRIPTION
Add keepalived_auto_restart variable (set to yes by default) to allow a keepalived modification without implying keepalived restart

Useful when applying new configuration on cluster but want to avoid keepalived switches between nodes (because of the keepalived restarts). Also avoid restarting both nodes at the same time...